### PR TITLE
isConnected fix

### DIFF
--- a/src/extensionProvider.ts
+++ b/src/extensionProvider.ts
@@ -92,7 +92,7 @@ export class ExtensionProvider {
   }
 
   async isConnected(): Promise<boolean> {
-    return !!this.account;
+    return Boolean(this.account.address);
   }
 
   async signTransaction<T extends ITransaction>(transaction: T): Promise<T> {


### PR DESCRIPTION
Because `!!{ address: '' }` will always be true, right? So in the previous form, `isConnected` will always return true.