### PR TITLE
Improved logout (wrt. UX).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elrondnetwork/erdjs-extension-provider",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elrondnetwork/erdjs-extension-provider",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@types/node": "17.0.23",
@@ -629,9 +629,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
-      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "funding": [
         {
@@ -644,9 +644,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001359",
-        "electron-to-chromium": "^1.4.172",
-        "node-releases": "^2.0.5",
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.4"
       },
       "bin": {
@@ -807,9 +807,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.188",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.188.tgz",
-      "integrity": "sha512-Zpa1+E+BVmD/orkyz1Z2dAT1XNUuVAHB3GrogfyY66dXN0ZWSsygI8+u6QTDai1ZayLcATDJpcv2Z2AZjEcr1A==",
+      "version": "1.4.189",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.189.tgz",
+      "integrity": "sha512-dQ6Zn4ll2NofGtxPXaDfY2laIa6NyCQdqXYHdwH90GJQW0LpJJib0ZU/ERtbb0XkBEmUD2eJtagbOie3pdMiPg==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -1718,14 +1718,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
-      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001359",
-        "electron-to-chromium": "^1.4.172",
-        "node-releases": "^2.0.5",
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.4"
       }
     },
@@ -1845,9 +1845,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.188",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.188.tgz",
-      "integrity": "sha512-Zpa1+E+BVmD/orkyz1Z2dAT1XNUuVAHB3GrogfyY66dXN0ZWSsygI8+u6QTDai1ZayLcATDJpcv2Z2AZjEcr1A==",
+      "version": "1.4.189",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.189.tgz",
+      "integrity": "sha512-dQ6Zn4ll2NofGtxPXaDfY2laIa6NyCQdqXYHdwH90GJQW0LpJJib0ZU/ERtbb0XkBEmUD2eJtagbOie3pdMiPg==",
       "dev": true
     },
     "escalade": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elrondnetwork/erdjs-extension-provider",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Signing provider for dApps: Maiar DeFi Wallet",
   "main": "out/index.js",
   "types": "out/index.d.js",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,3 +15,9 @@ export class ErrCannotSignSingleTransaction extends Err {
         super("Cannot sign single transaction.");
     }
 }
+
+export class ErrAccountNotConnected extends Err {
+    public constructor() {
+        super("Account is not connected.");
+    }
+}

--- a/src/extensionProvider.ts
+++ b/src/extensionProvider.ts
@@ -3,8 +3,6 @@ import { Address, Signature } from "./primitives";
 import { Operation } from "./operation";
 import { ErrAccountNotConnected, ErrCannotSignSingleTransaction } from "./errors";
 
-const disconnectedAccount = { address: "" };
-
 declare global {
   interface Window {
     elrondWallet: { extensionId: string };
@@ -18,7 +16,7 @@ interface IExtensionAccount {
 }
 
 export class ExtensionProvider {
-  public account: IExtensionAccount;
+  public account: IExtensionAccount = { address: "" };
   private initialized: boolean = false;
   private static _instance: ExtensionProvider = new ExtensionProvider();
 
@@ -28,7 +26,6 @@ export class ExtensionProvider {
         "Error: Instantiation failed: Use ExtensionProvider.getInstance() instead of new."
       );
     }
-    this.account = disconnectedAccount;
     ExtensionProvider._instance = this;
   }
 
@@ -73,12 +70,16 @@ export class ExtensionProvider {
     }
     try {
       await this.startBgrMsgChannel(Operation.Logout, this.account.address);
-      this.account = disconnectedAccount;
+      this.disconnect();
     } catch (error) {
       console.warn("Extension origin url is already cleared!", error);
     }
 
     return true;
+  }
+
+  private disconnect() {
+    this.account = { address: "" };
   }
 
   async getAddress(): Promise<string> {

--- a/src/extensionProvider.ts
+++ b/src/extensionProvider.ts
@@ -95,7 +95,8 @@ export class ExtensionProvider {
     return this.initialized;
   }
 
-  isConnected(): boolean {
+  // TODO: In V3, this will not be an async function anymore.
+  async isConnected(): Promise<boolean> {
     return Boolean(this.account.address);
   }
 
@@ -112,7 +113,7 @@ export class ExtensionProvider {
   }
 
   private ensureConnected() {
-    if (!this.isConnected()) {
+    if (!this.account.address) {
       throw new ErrAccountNotConnected();
     }
   }


### PR DESCRIPTION
dApp <-> extension provider improvements: 

 - `provider.account` object is cleared (set to a disconnected state) upon calling `logout()`
 - exceptions are now thrown if `provider.sign*()` methods are called while `provider.account` is disconnected.